### PR TITLE
Use relative length for default value for gaps to fix weird diagram when text size is not 11pt

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -348,7 +348,7 @@ let draw(
     // START OF ACTUAL IMPLEMENTATION
     let name = if style.name != none { style.name } else { name }
     cetz.draw.content(
-      (offset.cm(), y), 
+      (offset.to-absolute().cm(), y), 
       body,
       padding: style.padding,
       name: name,
@@ -368,7 +368,7 @@ let draw(
 
       let line-style = merge-dictionary(style.child-lines, child.style.parent-line)
     
-      let child-y = y - snapped-height.cm() - vertical-gap.cm()
+      let child-y = y - snapped-height.cm() - vertical-gap.to-absolute().cm()
       // let child-y = y - snapped-height.cm()
       let child-name = if child.style.name != none { child.style.name } else { name + "-" + str(i) }
     
@@ -424,11 +424,11 @@ let tree(
   /// The vertical gap between nodes
   ///
   /// -> length
-  vertical-gap: 8mm,
+  vertical-gap: 2.061818em,
   /// The horizontal gap between nodes
   ///
   /// -> length
-  horizontal-gap: 7mm,
+  horizontal-gap: 1.803636em,
   /// A code block to be inserted into the cetz canvas after the syntax tree. It can be used for drawing arrows between nodes. Remember to name nodes using ```typ #a``` in order to reference them. See Styling and Arguments for more.
   /// 
   code: none,


### PR DESCRIPTION
I'm using this package for slides, and I set text size to 22pt globally.

I found the diagram is weird:
<img width="158" height="144" alt="image" src="https://github.com/user-attachments/assets/e037182a-1faf-48fb-8515-36e8162bda94" />

After some investigation I found that the default value for `vertical-gap` and `horizontal-gap` are fixed to 7 or 8 mm, thus it would be too short when size is larger and too long when smaller.

I changed the value relative to current text size(1em) to fix this, and this works for my slides:
<img width="179" height="212" alt="image" src="https://github.com/user-attachments/assets/fceb8a7d-5660-435e-aa7b-b472ad3c6b6e" />


Maybe it would be more convenient for user to use if this kind of change is applied, otherwise they may need to configure the argument manually in case of a different text size, or hack into `lib.typ` and do something like what I've done.

Feel free to close this PR if you don't like it since I just worked on this for 3 minutes and it took me no work.

This is a very useful package and very easy to use. Thank you!